### PR TITLE
Update config.py for float-ieee

### DIFF
--- a/hw_device_mgr/lcec/config.py
+++ b/hw_device_mgr/lcec/config.py
@@ -110,6 +110,8 @@ class LCECConfig(EtherCATConfig):
                         hal_type = dt.hal_type_str()[4:].lower()
                         if hal_type == "float" and sdo.data_type.name.startswith("UINT"):
                             hal_type = "float-unsigned"
+                        if sdo.data_type.name.startswith("FLOAT"):
+                            hal_type = "float-ieee"
                         pdo_entry_xml.set("halType", hal_type)
                         pdo_entry_xml.set("halPin", entry["name"])
                         if "scale" in entry:


### PR DESCRIPTION
The hal lcec incorrectly interprets the ethercat.xml entry `float` with 32 bits as a `int32` and writes an int data structure to a float in memory. The conversion can be undone using:

`*((uint32_t*)&float_data) = msg->data;`

This PR requires pulling in these upstream changes to the pounce repo: https://github.com/sittner/linuxcnc-ethercat/blob/master/src/lcec_conf.c#L1265